### PR TITLE
New command to toggle between bullet and todo

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,19 +16,21 @@ ext install fabiospampinato.vscode-markdown-todo
 
 ## Usage
 
-It adds 2 commands to the command palette:
+It adds 3 commands to the command palette:
 
 ```js
 'Markdown Todo: Toggle Todo' // Toggle a todo
 'Markdown Todo: Toggle Done' // Toggle a todo as done
+'Markdown Todo: Toggle Todo Bullet' // Toggle a todo and bullet
 ```
 
-It adds 3 shortcuts when editing a `Markdown` file:
+It adds 4 shortcuts when editing a `Markdown` file:
 
 ```js
 'Cmd/Ctrl+Enter' // Triggers `Markdown Todo: Toggle Todo`
 'Alt+Enter' // Triggers `Markdown Todo: Toggle Todo`
 'Alt+D' // Triggers `Markdown Todo: Toggle Done`
+'Alt+T' // Triggers `Markdown Todo: Toggle Todo Bullet`
 ```
 
 ## Settings

--- a/package.json
+++ b/package.json
@@ -44,6 +44,10 @@
       {
         "command": "markdown.todo.toggleDone",
         "title": "Markdown Todo: Toggle Done"
+      },
+      {
+        "command": "markdown.todo.toggleTodoBullet",
+        "title": "Markdown Todo: Toggle Todo and Bullet"
       }
     ],
     "keybindings": [
@@ -62,6 +66,11 @@
         "command": "markdown.todo.toggleDone",
         "key": "Alt+d",
         "when": "editorTextFocus && editorLangId == markdown"
+      },
+      {
+        "command": "markdown.todo.toggleTodoBullet",
+        "key": "Alt+t",
+        "when": "editorTextFocus && editorLangId == markdown"
       }
     ],
     "menus": {
@@ -72,6 +81,10 @@
         },
         {
           "command": "markdown.todo.toggleDone",
+          "when": "editorLangId == markdown"
+        },
+        {
+          "command": "markdown.todo.toggleTodoBullet",
           "when": "editorLangId == markdown"
         }
       ]

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -71,6 +71,19 @@ function toggleDone () {
 
 }
 
+function toggleTodoBullet () {
+
+  const {bullet} = Consts.symbols,
+        {line, todoBox, todoDone} = Consts.regexes;
+
+  toggleRules (
+    [todoBox, `$1${bullet} $3`],
+    [todoDone, `$1${bullet} [ ] $3`],
+    [line, `$1${bullet} [ ] $3`]
+  );
+
+}
+
 /* EXPORT */
 
-export {toggleTodo, toggleDone};
+export {toggleTodo, toggleDone, toggleTodoBullet};


### PR DESCRIPTION
This is a proposed fix for #4.

- I'm don't know the best practice for defining short-cuts - should they be default disabled or some such? `alt-t` conflicts with the terminal menu item but that is what I would choose to use
-  it's a bit tricky to distinguish between the two types of toggle. Personally I never want to toggle between "plain text" and "todo bullet" and only ever between "bullet" and "todo bullet"